### PR TITLE
VOL-5595:Event failure fixes

### DIFF
--- a/internal/pkg/core/device_handler.go
+++ b/internal/pkg/core/device_handler.go
@@ -2166,6 +2166,15 @@ func (dh *DeviceHandler) onuIndication(ctx context.Context, onuInd *oop.OnuIndic
 		return olterrors.NewErrNotFound("onu-device", errFields, err)
 	}
 
+	//If onu indication down and onu disc indication of another onu happens parallelly, then onuid with incorrect serial number is fetched
+	if onuInd.OperState == "down" && onuDevice.SerialNumber != "" && serialNumber != "" && onuDevice.SerialNumber != serialNumber {
+		logger.Warnw(ctx, "onu-serial-number-mismatch-possible", log.Fields{
+			"expected-serial-number-from-indication": serialNumber,
+			"received-serial-number-from-core":       onuDevice.SerialNumber,
+			"device-id":                              dh.device.Id})
+		return nil
+	}
+
 	if onuDevice.ParentPortNo != ponPort {
 		logger.Warnw(ctx, "onu-is-on-a-different-intf-id-now", log.Fields{
 			"previousIntfId": onuDevice.ParentPortNo,


### PR DESCRIPTION
RCA:
When delete of Onu(A) happened first later  Onu(A) down indication came  and Onu(B) discovery indication happens paralley, Onuid of Onu(A)  is released and assigned to Onu(B). At the OLT adapter onu key formed at the cache (interface id+ onuid)  will have Onu(B). When down indication of Onu(A) comes it fetches  Onu(B) data from cache and sents down indication to onu adapter.Onu adapter processed Onu(B) down indication

Fix:
We check the cache data check whether cache and onu indication serial numbers are same, if not same and it is onu down indication then the down indication can be dropped as onu is already cleaned from voltha.